### PR TITLE
Add reset on L+R

### DIFF
--- a/arm9/source/emulator.c
+++ b/arm9/source/emulator.c
@@ -325,6 +325,21 @@ start(Uxn *u)
 		// X+Y in debugger mode resets tticks_peak
 		if ((keysHeld() & (KEY_X | KEY_Y)) == (KEY_X | KEY_Y))
 			memset(tticks_peak, 0, sizeof(tticks_peak));
+
+		int held = keysDown() | keysHeld();
+		// On the first frame that L+R are held
+		if ((keysDown() & (KEY_R | KEY_L)) &&
+			((held & (KEY_R | KEY_L)) == (KEY_R | KEY_L))) {
+			// reset the cpu
+			if(!resetuxn(u))
+				return error("Resetting", "Failed");
+			if(!loaduxn(u, "boot.rom"))
+				return error("Load", "Failed");
+			if(!initppu(&ppu))
+				return error("PPU", "Init failure");
+			evaluxn(u, 0x0100);
+		}
+
 		tticks = timer_ticks(0);
 #endif
 		doctrl(u);

--- a/arm9/source/emulator.c
+++ b/arm9/source/emulator.c
@@ -325,6 +325,8 @@ start(Uxn *u)
 		// X+Y in debugger mode resets tticks_peak
 		if ((keysHeld() & (KEY_X | KEY_Y)) == (KEY_X | KEY_Y))
 			memset(tticks_peak, 0, sizeof(tticks_peak));
+		tticks = timer_ticks(0);
+#endif
 
 		int held = keysDown() | keysHeld();
 		// On the first frame that L+R are held
@@ -340,8 +342,6 @@ start(Uxn *u)
 			evaluxn(u, 0x0100);
 		}
 
-		tticks = timer_ticks(0);
-#endif
 		doctrl(u);
 		domouse(u);
 #ifdef DEBUG_PROFILE

--- a/arm9/source/emulator.c
+++ b/arm9/source/emulator.c
@@ -311,6 +311,9 @@ profiler_ticks(Uint32 tticks, int pos, const char *name)
 }
 #endif
 
+#define RESET_KEYS (KEY_R | KEY_L)
+#define TICK_RESET_KEYS (KEY_X | KEY_Y)
+
 int
 start(Uxn *u)
 {
@@ -323,15 +326,15 @@ start(Uxn *u)
 		scanKeys();
 #ifdef DEBUG_PROFILE
 		// X+Y in debugger mode resets tticks_peak
-		if ((keysHeld() & (KEY_X | KEY_Y)) == (KEY_X | KEY_Y))
+		if ((keysHeld() & TICK_RESET_KEYS) == TICK_RESET_KEYS)
 			memset(tticks_peak, 0, sizeof(tticks_peak));
 		tticks = timer_ticks(0);
 #endif
 
 		int held = keysDown() | keysHeld();
 		// On the first frame that L+R are held
-		if ((keysDown() & (KEY_R | KEY_L)) &&
-			((held & (KEY_R | KEY_L)) == (KEY_R | KEY_L))) {
+		if ((keysDown() & RESET_KEYS) &&
+			((held & RESET_KEYS) == RESET_KEYS)) {
 			// reset the cpu
 			if(!resetuxn(u))
 				return error("Resetting", "Failed");

--- a/arm9/source/uxn.c
+++ b/arm9/source/uxn.c
@@ -4043,6 +4043,24 @@ bootuxn(Uxn *u)
         return 1;
 }
 
+int resetuxn(Uxn *u)
+{
+	// Reset the stacks
+	memset(&(u->wst), 0, sizeof(Stack));
+	memset(&(u->rst), 0, sizeof(Stack));
+
+	Device *device;
+	for (int i = 0; i < 16; i++) {
+		device = &(u->dev[i]);
+		memset(device->dat, 0, 16);
+		device->vector = (Uint16) 0;
+	}
+
+	// Reset RAM
+	memset(u->ram.dat, 0, 65536);
+	return 1;
+}
+
 int
 loaduxn(Uxn *u, char *filepath)
 {

--- a/include/uxn.h
+++ b/include/uxn.h
@@ -61,5 +61,6 @@ static inline Uint16 peek16(Uint8 *m, Uint16 a) { return (peek8(m, a) << 8) + pe
 
 int loaduxn(Uxn *c, char *filepath);
 int bootuxn(Uxn *c);
+int resetuxn(Uxn *c);
 int evaluxn(Uxn *u, Uint16 vec);
 Device *portuxn(Uxn *u, Uint8 id, char *name, int (*talkfn)(Device *, Uint8, Uint8));


### PR DESCRIPTION
Here's a preliminary commit to reset the screen and Uxn CPU upon pressing L+R together. I wasn't sure where to put it so I put it next to the X+Y input check. Please let me know if there's somewhere better it should go!

This will make it much easier to switch ROMs on the DS once we have a proper launcher program that can run at boot.rom :)